### PR TITLE
READMEs: simplify and rely on links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-## Hi there 👋 we're ROOST (Robust Open Online Safety Tools)
+# .github
 
-![a minimalist logo of a bird sitting on a box, a play on modularity and tools coming home to roost](https://roost.tools/images/logos/roost.svg "ROOST.tools")
-
-ROOST is a new non-profit organization that brings together the expertise, resources, and investments of major technology companies and philanthropies to build scalable, interoperable safety infrastructure suited for the AI era. 
+This repo holds special, cross-project files for [@roostorg](https://github.com/roostorg), the ROOST GitHub organization.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,25 +1,11 @@
-## Hi there 👋 we're ROOST (Robust Open Online Safety Tools)
-
 ![a minimalist logo of a bird sitting on a box, a play on modularity and tools coming home to roost](https://roost.tools/images/logos/roost.svg "ROOST.tools")
 
-[ROOST](https://roost.tools) is a new non-profit organization that provides modular, open-source infrastructure for online safety. We serve product teams, trust & safety leads, and community moderators who need to review, triage, and enforce on harmful content  without building everything from scratch or relying on opaque or expensive vendor tools. ROOST is building tools with a focus on modular, self-hostable, and interoperable components. 
+[ROOST](https://roost.tools) (Robust Open Online Safety Tools) is a new non-profit organization that provides modular, open-source infrastructure for online safety. We serve product teams, trust & safety leads, and community moderators who need to review, triage, and enforce on harmful content without building everything from scratch or relying on opaque or expensive vendor tools. We build tools with a focus on modular, self-hostable, and interoperable components.
 
+[View our roadmap](https://github.com/roostorg/community/blob/main/roadmap.md) • [Join our community](https://github.com/roostorg/community)
 
-## Our Team
-We are a small but mighty team dispersed and remote-first. Our founding partners include Eric Schmidt, Discord, OpenAI, Google, Roblox, John S. and James L. Knight Foundation, AI Collaborative, Patrick J. McGovern Foundation and Project Liberty Institute. ROOST also benefits from the support and expertise of a wide set of partners from the fields of AI, philanthropy, academia, open source, child safety, and countering violent extremism.
+## Our Team & Partners
 
-## Why ROOST?
-Many organizations – big and small – still lack access to basic safety resources, hindering innovation and putting users at risk.
+We are a small but mighty [team](https://roost.tools/who-we-are/) dispersed and remote-first.
 
-ROOST develops, maintains, and distributes open source building blocks to safeguard global users and communities. Backed by dedicated technical teams and leading experts, ROOST meets organizations where they are and provides hands-on support at every stage of their safety journey.
-
-## Initial Product Roadmap
-
-### Child Safety
-Many companies struggle to meet basic child safety needs because existing tools are either expensive, gate-kept, challenging to implement, and/or only partial solutions. ROOST works to close that digital safety gap.
-
-### Foundation model-powered content safeguards
-ROOST partners with leading developers to build a community of practice for foundation model-powered content safeguards. We identify and fill critical gaps in this space, for instance around specific training and evaluation datasets for content safety.
-
-### Core Safety Infrastructure
-ROOST focuses on high quality, open versions of core tools that immediately add value and avoid unnecessary duplication, such as rules engines, case management systems, review consoles, wrappers that provide standardized data formats and a unified interface to different APIs, etc
+Our founding [partners](https://roost.tools/partnerships) include Eric Schmidt, Discord, OpenAI, Google, Roblox, John S. and James L. Knight Foundation, AI Collaborative, Patrick J. McGovern Foundation and Project Liberty Institute. ROOST also benefits from the support and expertise of a wide set of partners from the fields of AI, philanthropy, academia, open source, child safety, and countering violent extremism.


### PR DESCRIPTION
This profile appears at the top of our org page, meaning the longer it is, the more it pushes away access to the code. In the spirit of "less talk, more code," I think we can link out to relevant resources here but make it a lot more concise so folks can get at the code more easily.

Fixes https://github.com/roostorg/community/issues/13